### PR TITLE
Improve overview performance by calculating timestamp outside iterator

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,11 +75,12 @@ fn print_overview(occurrences: &[CommitOccurrence]) {
         "Unique committers: {:?}",
         occurrences.iter().unique_by(|c| &c.name).count()
     );
+    let six_months_ago = chrono::Local::now() - chrono::Duration::weeks(26);
     println!(
         "Recent committers: {:?}",
         occurrences
             .iter()
-            .filter(|c| c.at > chrono::Local::now() - chrono::Duration::weeks(26))
+            .filter(|c| c.at > six_months_ago)
             .unique_by(|c| &c.name)
             .count()
     );


### PR DESCRIPTION
What?
=====

For repositories with a large number of commits, filtering to the most
recent six months when that calculation occurs within the iterator can
be time-consuming.

This shifts the calculation of the six-month window outside of the
iterator to reduce the number of times we calculate this value to one.