### PR TITLE
Introduce `churn` subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,8 +35,8 @@ pub fn run() -> Result<(), CliError> {
                 verbose,
             );
         }
-
         Some(Command::GenerateMailmap) => mailmap::generate(&build_occurrences(&mailmap, &commits)),
+        Some(Command::Churn) => print_churn(&repo, &commits),
     }
 
     Ok(())
@@ -182,5 +182,11 @@ fn print_periodic_team_changes<P: Period>(
         }
 
         prior_authors = current_authors;
+    }
+}
+
+fn print_churn<'a>(repo: &'a Repository, commits: &'a [Commit]) {
+    for (path, change_count) in git::build_churn(repo, commits) {
+        println!("{:>5} {}", change_count, path.to_string_lossy());
     }
 }

--- a/src/cli/flags.rs
+++ b/src/cli/flags.rs
@@ -18,6 +18,8 @@ pub enum Command {
     },
     /// Print a mailmap file to STDOUT based on repository contributors
     GenerateMailmap,
+    /// Print the number of times each file has been modified
+    Churn,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,14 @@
+use git2::{Commit, Repository};
+
+pub fn retrieve_commits<'a>(repo: &'a Repository) -> Result<Vec<Commit<'a>>, git2::Error> {
+    let mut revwalk = repo.revwalk()?;
+
+    revwalk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
+    revwalk.push_head()?;
+
+    let revwalk = revwalk
+        .filter_map(Result::ok)
+        .filter_map(|id| repo.find_commit(id).ok());
+
+    Ok(revwalk.collect())
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,6 @@
-use git2::{Commit, Repository};
+use git2::{Commit, Delta, Diff, DiffDelta, Repository};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 pub fn retrieve_commits<'a>(repo: &'a Repository) -> Result<Vec<Commit<'a>>, git2::Error> {
     let mut revwalk = repo.revwalk()?;
@@ -11,4 +13,51 @@ pub fn retrieve_commits<'a>(repo: &'a Repository) -> Result<Vec<Commit<'a>>, git
         .filter_map(|id| repo.find_commit(id).ok());
 
     Ok(revwalk.collect())
+}
+
+enum Operation {
+    Add,
+    Remove,
+}
+
+fn delta_operation(delta: &DiffDelta) -> Option<(PathBuf, Operation)> {
+    match (delta.status(), delta.new_file().path()) {
+        (Delta::Added, Some(path)) => Some((path.to_path_buf(), Operation::Add)),
+        (Delta::Deleted, Some(path)) => Some((path.to_path_buf(), Operation::Remove)),
+        (Delta::Modified, Some(path)) => Some((path.to_path_buf(), Operation::Add)),
+        _ => None,
+    }
+}
+
+pub fn build_churn(repo: &Repository, commits: &[Commit]) -> BTreeMap<PathBuf, usize> {
+    commits
+        .iter()
+        .filter_map(|commit| build_diff(repo, commit).ok())
+        .fold(BTreeMap::new(), |mut changes, diff| {
+            for delta in diff.deltas() {
+                match delta_operation(&delta) {
+                    Some((path, Operation::Add)) => {
+                        *changes.entry(path).or_insert(0) += 1;
+                    }
+                    Some((path, Operation::Remove)) => {
+                        changes.remove(&path);
+                    }
+                    _ => (),
+                }
+            }
+
+            changes
+        })
+}
+
+fn build_diff<'a>(repo: &'a Repository, commit: &'a Commit) -> Result<Diff<'a>, git2::Error> {
+    let parent_tree = if commit.parents().len() == 1 {
+        let parent = commit.parent(0)?;
+        Some(parent.tree()?)
+    } else {
+        None
+    };
+    let tree = commit.tree()?;
+
+    repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@
 
 pub mod cli;
 mod commit_occurrence;
+mod git;
 mod grouped_by_date;
 mod mailmap;


### PR DESCRIPTION
What?
=====

This introduces a rudimentary file churn calculation by traversing diffs
and, based on the diff status, tracks additions, removals, and
modifications of each path.

This currently only accounts for a subset of diff delta statuses,
notably added, removed, and modified statuses. As far as I can tell,
libgit2 does not correctly report the renamed status correctly even in
the simplest of cases (e.g. using `git mv current_path new_path`).
Currently, this is reported as two separate deltas, one with "added"
status and one with "deleted" status.

In the future, it would be beneficial to support this case by
effectively replacing the old `PathBuf` within the `BTreeMap` with the
new `PathBuf`, maintaining changes count.